### PR TITLE
Building NextJS server app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "yargs": "17.7.2"
       },
       "bin": {
-        "@dbb-next": "dist/index.js"
+        "next-serverless-deployment": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "20.12.11",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "./dist/index.js",
   "bin": {
-    "@dbb-next": "./dist/index.js"
+    "@dbbs/next-serverless-deployment": "./dist/index.js"
   },
   "exports": {
     "./*": "./dist/*"

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,29 +1,53 @@
-import fs from 'node:fs'
 import childProcess from 'node:child_process'
+import fs from 'node:fs'
+import path from 'path'
+import { getProjectSettings, ProjectPackager } from '../utils'
+
+const OUTPUT_FOLDER = 'dbbs-next'
 
 const setNextOptions = () => {
   // Same as `target: "standalone"` in next.config.js
   process.env.NEXT_PRIVATE_STANDALONE = 'true'
 }
 
-const getPackager = () => {
-  return (
-    [
-      { lockFile: 'package-lock.json', packager: 'npm' },
-      { lockFile: 'yarn.lock', packager: 'yarn' },
-      { lockFile: 'pnpm-lock.yaml', packager: 'pnpm' }
-    ].find((packager) => fs.existsSync(`./${packager.lockFile}`))?.packager ?? 'npm'
-  )
+const buildNextApp = (packager: ProjectPackager) => {
+  childProcess.execSync(packager.buildCommand, { stdio: 'inherit' })
 }
 
-const buildNextApp = (packager: string) => {
-  const command = packager === 'npm' ? 'npm run build' : `${packager} build`
+const createOutputFolder = () => {
+  const outputFolderPath = path.join(process.cwd(), OUTPUT_FOLDER)
+  // clean folder before creating new build output.
+  fs.rmSync(outputFolderPath, { recursive: true, force: true })
 
-  childProcess.execSync(command, { stdio: 'inherit' })
+  fs.mkdirSync(outputFolderPath)
+
+  return outputFolderPath
+}
+
+const copyAssets = (outputPath: string, appPath: string, appRelativePath: string) => {
+  // Copying static assets (like js, css, images, .etc)
+  fs.cpSync(path.join(appPath, '.next', 'static'), path.join(outputPath, '_next', 'static'), { recursive: true })
+
+  fs.cpSync(path.join(appPath, '.next', 'standalone'), path.join(outputPath, 'server'), {
+    recursive: true
+  })
+  fs.cpSync(path.join(outputPath, 'server', appRelativePath), path.join(outputPath, 'server'), { recursive: true })
+  fs.rmSync(path.join(outputPath, 'server', appRelativePath), { recursive: true })
 }
 
 export const buildApp = () => {
-  const packager = getPackager()
+  const currentPath = process.cwd()
+  const settings = getProjectSettings(currentPath)
+
+  if (!settings) {
+    throw new Error('Was not able to find project settings.')
+  }
+
+  const { packager, root: rootPath } = settings
+  const appRelativePath = path.relative(rootPath, currentPath)
+
   setNextOptions()
   buildNextApp(packager)
+  const outputPath = createOutputFolder()
+  copyAssets(outputPath, currentPath, appRelativePath)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { deploy } from './commands/deploy'
+import { buildApp } from './commands/build'
 
 interface CLIOptions {
   siteName: string
@@ -57,6 +58,15 @@ cli.command<CLIOptions>(
         awsSecretAccessKey
       }
     })
+  }
+)
+
+cli.command(
+  'build',
+  'build the app',
+  () => {},
+  () => {
+    buildApp()
   }
 )
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs'
+import path from 'path'
+
+export interface ProjectPackager {
+  type: 'npm' | 'yarn' | 'pnpm'
+  lockFile: 'package-lock.json' | 'yarn.lock' | 'pnpm-lock.yaml'
+  buildCommand: string
+}
+
+export interface ProjectSettings {
+  root: string
+  packager: ProjectPackager
+  isMonorepo: boolean
+}
+
+export const findPackager = (appPath: string): ProjectPackager | undefined => {
+  return (
+    [
+      { lockFile: 'package-lock.json', type: 'npm', buildCommand: 'npm ru build' },
+      { lockFile: 'yarn.lock', type: 'yarn', buildCommand: 'yarn build' },
+      { lockFile: 'pnpm-lock.yaml', type: 'pnpm', buildCommand: 'pnpm build' }
+    ] satisfies ProjectPackager[]
+  ).find((packager) => fs.existsSync(path.join(appPath, `${packager.lockFile}`)))
+}
+
+export const getProjectSettings = (projectPath: string): ProjectSettings | undefined => {
+  let currentPath = projectPath
+
+  while (currentPath !== '/') {
+    const packager = findPackager(currentPath)
+
+    if (packager) {
+      return { root: currentPath, packager, isMonorepo: currentPath !== projectPath }
+    }
+
+    currentPath = path.dirname(currentPath)
+  }
+}


### PR DESCRIPTION
- updated a way to find `packager` and get project paths
- added logic to check if app inside monorepo (nextjs has different output for the app inside monorepo)
- added creating output folder
- copying assets and server code to output folder
- added separate command to build the app `@dbbs/next-serverless-deployment build`

Next Step:
1. Gzip output folder and deploy to EB

Feature:
Divide assets from server code and deploy them to s3