### PR TITLE
Feat/platform 696: accept custom cloudfront distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Creates AWS resources for NextJS application if they were not created. Bundles N
 | profile           | string  | none          | AWS profile to use for credentials. If parameter is empty going to read credentials from:<br>process.env.AWS_ACCESS_KEY_ID and process.env.AWS_SECRET_ACCESS_KEY |
 | nodejs            | string  | 20            | Supports nodejs v18 and v20                                                                                                                                       |
 | production        | boolean | false         | Identifies if you want to create production AWS resources. So they are going to have different delete policies to keep data in safe.                              |
+| cloudFrontId      | string  | none          | Existing cloud front distribution id. Useful for when new cloudfront distribution isn't needed                                                                  |
 
 ## Architecture
 

--- a/src/cdk/constructs/CheckExpirationLambdaEdge.ts
+++ b/src/cdk/constructs/CheckExpirationLambdaEdge.ts
@@ -7,6 +7,7 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import path from 'node:path'
 import { buildLambda } from '../../build/edge'
 import { CacheConfig } from '../../types'
+import { addOutput } from '../../common/cdk'
 
 interface CheckExpirationLambdaEdgeProps extends cdk.StackProps {
   bucketName: string
@@ -62,5 +63,6 @@ export class CheckExpirationLambdaEdge extends Construct {
     })
 
     this.lambdaEdge.addToRolePolicy(policyStatement)
+    addOutput(this, `${id}-CheckExpirationFunctionArn`, this.lambdaEdge.functionArn)
   }
 }

--- a/src/cdk/constructs/CloudFrontDistribution.ts
+++ b/src/cdk/constructs/CloudFrontDistribution.ts
@@ -90,5 +90,7 @@ export class CloudFrontDistribution extends Construct {
     })
 
     addOutput(this, `${id}-CloudfrontDistributionId`, this.cf.distributionId)
+    addOutput(this, `${id}-SplitCachePolicyId`, splitCachePolicy.cachePolicyId)
+    addOutput(this, `${id}-LongCachePolicyId`, splitCachePolicy.cachePolicyId)
   }
 }

--- a/src/cdk/constructs/RoutingLambdaEdge.ts
+++ b/src/cdk/constructs/RoutingLambdaEdge.ts
@@ -7,6 +7,7 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import path from 'node:path'
 import { buildLambda } from '../../build/edge'
 import { CacheConfig } from '../../types'
+import { addOutput } from '../../common/cdk'
 
 interface RoutingLambdaEdgeProps extends cdk.StackProps {
   bucketName: string
@@ -62,5 +63,6 @@ export class RoutingLambdaEdge extends Construct {
     })
 
     this.lambdaEdge.addToRolePolicy(policyStatement)
+    addOutput(this, `${id}-RoutingFunctionArn`, this.lambdaEdge.functionArn)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ interface CLIOptions {
   profile?: string
   nodejs?: string
   production?: boolean
+  cloudFrontId?: string
 }
 
 const cli = yargs(hideBin(process.argv))
@@ -46,6 +47,10 @@ const cli = yargs(hideBin(process.argv))
     description: 'Creates production stack.',
     default: false
   })
+  .option('cloudFrontId', {
+    type: 'string',
+    describe: 'Existing cloudfront Id.'
+  })
 
 cli.command<CLIOptions>(
   'bootstrap',
@@ -62,7 +67,7 @@ cli.command<CLIOptions>(
   'app deployment',
   () => {},
   async (argv) => {
-    const { siteName, pruneBeforeDeploy, stage, region, profile, nodejs, production } = argv
+    const { siteName, pruneBeforeDeploy, stage, region, profile, nodejs, production, cloudFrontId } = argv
 
     await deploy({
       siteName,
@@ -70,6 +75,7 @@ cli.command<CLIOptions>(
       pruneBeforeDeploy,
       nodejs,
       isProduction: production,
+      cloudFrontId,
       aws: {
         region,
         profile


### PR DESCRIPTION
- if custom cloudfront was passed, avoid creating new cloudfront and use existing instead
- attach origin, update existing behavior and add additional behaviors for existing cloudfront together with lambda edge