### PR TITLE
feat: added support of nextjs rewrites

### DIFF
--- a/src/cdk/constructs/OriginRequestLambdaEdge.ts
+++ b/src/cdk/constructs/OriginRequestLambdaEdge.ts
@@ -6,7 +6,7 @@ import * as logs from 'aws-cdk-lib/aws-logs'
 import * as iam from 'aws-cdk-lib/aws-iam'
 import path from 'node:path'
 import { buildLambda } from '../../common/esbuild'
-import { CacheConfig } from '../../types'
+import { CacheConfig, NextRewrites } from '../../types'
 
 interface OriginRequestLambdaEdgeProps extends cdk.StackProps {
   bucketName: string
@@ -15,7 +15,8 @@ interface OriginRequestLambdaEdgeProps extends cdk.StackProps {
   nodejs?: string
   cacheConfig: CacheConfig
   bucketRegion?: string
-  nextCachedRoutesMatchers: string[]
+  cachedRoutesMatchers: string[]
+  rewritesConfig: NextRewrites
 }
 
 const NodeJSEnvironmentMapping: Record<string, lambda.Runtime> = {
@@ -34,7 +35,8 @@ export class OriginRequestLambdaEdge extends Construct {
       nodejs,
       buildOutputPath,
       cacheConfig,
-      nextCachedRoutesMatchers
+      cachedRoutesMatchers,
+      rewritesConfig
     } = props
     super(scope, id)
 
@@ -47,7 +49,8 @@ export class OriginRequestLambdaEdge extends Construct {
         'process.env.S3_BUCKET_REGION': JSON.stringify(bucketRegion ?? ''),
         'process.env.EB_APP_URL': JSON.stringify(renderServerDomain),
         'process.env.CACHE_CONFIG': JSON.stringify(cacheConfig),
-        'process.env.NEXT_CACHED_ROUTES_MATCHERS': JSON.stringify(nextCachedRoutesMatchers ?? [])
+        'process.env.NEXT_CACHED_ROUTES_MATCHERS': JSON.stringify(cachedRoutesMatchers ?? []),
+        'process.env.NEXT_REWRITES_CONFIG': JSON.stringify(rewritesConfig ?? [])
       }
     })
 

--- a/src/cdk/stacks/NextCloudfrontStack.ts
+++ b/src/cdk/stacks/NextCloudfrontStack.ts
@@ -5,7 +5,7 @@ import { OriginRequestLambdaEdge } from '../constructs/OriginRequestLambdaEdge'
 import { CloudFrontDistribution } from '../constructs/CloudFrontDistribution'
 import { ViewerResponseLambdaEdge } from '../constructs/ViewerResponseLambdaEdge'
 import { ViewerRequestLambdaEdge } from '../constructs/ViewerRequestLambdaEdge'
-import { DeployConfig, NextRedirects, NextI18nConfig } from '../../types'
+import { DeployConfig, NextRedirects, NextI18nConfig, NextRewrites } from '../../types'
 
 export interface NextCloudfrontStackProps extends StackProps {
   nodejs?: string
@@ -17,7 +17,8 @@ export interface NextCloudfrontStackProps extends StackProps {
   imageTTL?: number
   redirects?: NextRedirects
   nextI18nConfig?: NextI18nConfig
-  nextCachedRoutesMatchers: string[]
+  cachedRoutesMatchers: string[]
+  rewritesConfig: NextRewrites
 }
 
 export class NextCloudfrontStack extends Stack {
@@ -37,8 +38,9 @@ export class NextCloudfrontStack extends Stack {
       deployConfig,
       imageTTL,
       redirects,
-      nextCachedRoutesMatchers,
-      nextI18nConfig
+      cachedRoutesMatchers,
+      nextI18nConfig,
+      rewritesConfig
     } = props
 
     this.originRequestLambdaEdge = new OriginRequestLambdaEdge(this, `${id}-OriginRequestLambdaEdge`, {
@@ -48,7 +50,8 @@ export class NextCloudfrontStack extends Stack {
       buildOutputPath,
       cacheConfig: deployConfig.cache,
       bucketRegion: region,
-      nextCachedRoutesMatchers
+      cachedRoutesMatchers,
+      rewritesConfig
     })
 
     this.viewerRequestLambdaEdge = new ViewerRequestLambdaEdge(this, `${id}-ViewerRequestLambdaEdge`, {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -113,7 +113,7 @@ export const deploy = async (config: DeployConfig) => {
     const siteNameLowerCased = siteName.toLowerCase()
 
     // Build and zip app.
-    const { nextCachedRoutesMatchers } = await buildApp({
+    const { cachedRoutesMatchers, rewritesConfig } = await buildApp({
       projectSettings,
       outputPath
     })
@@ -157,7 +157,8 @@ export const deploy = async (config: DeployConfig) => {
         imageTTL: nextConfig.imageTTL,
         nextI18nConfig,
         redirects: nextRedirects,
-        nextCachedRoutesMatchers,
+        cachedRoutesMatchers,
+        rewritesConfig,
         env: {
           region: AWS_EDGE_REGION // required since Edge can be deployed only here.
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next/types'
+import type { RouteHas } from 'next/dist/lib/load-custom-routes'
 
 export interface CacheConfig {
   noCacheRoutes?: string[]
@@ -14,3 +15,12 @@ export interface DeployConfig {
 export type NextRedirects = Awaited<ReturnType<Required<NextConfig>['redirects']>>
 
 export type NextI18nConfig = NextConfig['i18n']
+
+export type NextRewriteEntity = {
+  source: string
+  destination: string
+  regex: string
+  has?: RouteHas[]
+}
+
+export type NextRewrites = NextRewriteEntity[]


### PR DESCRIPTION
# Add Next.js Rewrites Support

This PR adds support for Next.js rewrites functionality, allowing the application to internally rewrite URLs without changing the URL in the browser.

## Key Changes

### 1. Build Process Updates (`src/build/next.ts`)
- Added `getRewritesConfig` function to parse Next.js rewrite rules from manifest
- Renamed `getNextCachedRoutesMatchers` to `getNextCachedRoutesConfig`
- Updated return type to include both cached routes and rewrites configuration
- Handles both array and object-based rewrite configurations:
  - `beforeFiles`
  - `afterFiles`
  - `fallback`

### 2. Type Definitions (`src/types/index.ts`)
- Added new types for rewrite functionality:
```typescript
export type NextRewriteEntity = {
source: string
destination: string
regex: string
has?: RouteHas[]
}
export type NextRewrites = NextRewriteEntity[]
```

- Imported `RouteHas` from Next.js for type safety

### 3. Lambda@Edge Handler Updates (`src/lambdas/originRequest.ts`)
- Added new validation functions:
  - `validateRouteHasMatch`: Validates rewrite conditions
    - Header matching
    - Query parameter validation
    - Cookie checking
  - `validateRewriteRoute`: Processes rewrite rules against incoming requests
- Updated handler to process rewrites before request handling

### 4. Infrastructure Updates
- Modified `OriginRequestLambdaEdge` construct:
  - Added `rewritesConfig` prop
  - Updated environment variables to include rewrites
- Updated `NextCloudfrontStack`:
  - Added rewrite configuration propagation
  - Maintained backward compatibility

## Implementation Details

### Rewrite Rule Processing
- Supports all Next.js rewrite conditions:
  - Headers
  - Query parameters
  - Cookies
  - Path regex matching
- Maintains original rewrite order from Next.js config
- Integrates seamlessly with existing caching mechanism
