### PR TITLE
chore: updated chart with dynamodb and removed response origin lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ sequenceDiagram
     participant User
     participant CloudFront
     participant Request Origin Lambda@Edge
-    participant Response Origin Lambda@Edge
     participant S3Bucket
+    participant DynamoDB
     participant ElasticBeanstalk with Load Balancer
 
     %% Flows
@@ -110,17 +110,15 @@ sequenceDiagram
     Request Origin Lambda@Edge ->> S3Bucket: Sends Head request to check if file exists in S3
     alt File exists in S3
       Request Origin Lambda@Edge ->> S3Bucket: Forwarding request to S3 origin
-      S3Bucket ->> Response Origin Lambda@Edge: lambda edge listener
-      Response Origin Lambda@Edge ->> CloudFront: returns result from s3 origin
-        alt File is expired in S3
-          Response Origin Lambda@Edge ->> CloudFront: sets cache header to no-cache to avoid caching of stale data
-        else
-          Response Origin Lambda@Edge ->> CloudFront: forwards request from S3 origin
-        end
+    else File exists in S3 but is expired
+      Request Origin Lambda@Edge ->> ElasticBeanstalk with Load Balancer: Forwarding request to render server
+      ElasticBeanstalk with Load Balancer ->> S3Bucket: stores generated page
+      ElasticBeanstalk with Load Balancer ->> DynamoDB: updates page cache metadata
     else File does not exit
       Request Origin Lambda@Edge ->> ElasticBeanstalk with Load Balancer: Sends request to render page when it does not exist in S3
       ElasticBeanstalk with Load Balancer ->> CloudFront: returns generated page
       ElasticBeanstalk with Load Balancer ->> S3Bucket: stores generated page
+      ElasticBeanstalk with Load Balancer ->> DynamoDB: stores page cache metadata
     end
     CloudFront ->> User: returns page result
 ```


### PR DESCRIPTION
This PR updates the sequence diagram in our README.md to reflect the current architecture, particularly around page caching and DynamoDB integration.

## Key Changes

### 1. Architecture Flow Updates
- Removed Response Origin Lambda@Edge from the flow
- Added DynamoDB as a new participant in the system
- Updated the caching logic flow to include DynamoDB metadata storage

### 2. Cache Management
- Added explicit handling of expired S3 files:
  - Requests for expired files now go to the render server
  - Generated pages are stored back in S3
  - Cache metadata is updated in DynamoDB
- Simplified the S3 file existence check flow