### PR TITLE
feat: enabled compression and uploading public assets

### DIFF
--- a/src/build/next.ts
+++ b/src/build/next.ts
@@ -39,6 +39,9 @@ const copyAssets = async (outputPath: string, appPath: string, appRelativePath: 
       recursive: true
     }
   )
+  await fs.cp(path.join(appPath, 'public'), path.join(outputPath, '.next', 'standalone', appRelativePath, 'public'), {
+    recursive: true
+  })
 }
 
 const getRewritesConfig = (manifestRules: RoutesManifest['rewrites']): NextRewrites => {

--- a/src/cacheHandler/strategy/s3.ts
+++ b/src/cacheHandler/strategy/s3.ts
@@ -78,6 +78,7 @@ export class S3Cache implements CacheStrategy {
       })
     }
     const input: PutObjectCommandInput = { ...baseInput }
+    const tagsValue = [headersTags, this.buildTagKeys(data.tags)].filter(Boolean).join('&')
 
     const promises = [
       this.#dynamoDBClient.putItem({
@@ -86,8 +87,9 @@ export class S3Cache implements CacheStrategy {
           pageKey: { S: pageKey },
           cacheKey: { S: cacheKey },
           s3Key: { S: baseInput.Key! },
-          tags: { S: [headersTags, this.buildTagKeys(data.tags)].filter(Boolean).join('&') },
-          createdAt: { S: new Date().toISOString() }
+          createdAt: { S: new Date().toISOString() },
+          // TODO: check for empty tags
+          ...(tagsValue && { tags: { S: tagsValue } })
         }
       })
     ]

--- a/src/cdk/stacks/NextCloudfrontStack.ts
+++ b/src/cdk/stacks/NextCloudfrontStack.ts
@@ -77,7 +77,7 @@ export class NextCloudfrontStack extends Stack {
       requestEdgeFunction: this.originRequestLambdaEdge.lambdaEdge,
       viewerResponseEdgeFunction: this.viewerResponseLambdaEdge.lambdaEdge,
       viewerRequestLambdaEdge: this.viewerRequestLambdaEdge.lambdaEdge,
-      cacheConfig: deployConfig.cache,
+      deployConfig: deployConfig,
       imageTTL
     })
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -208,6 +208,18 @@ export const deploy = async (config: DeployConfig) => {
       folderRootPath: path.join(outputPath, '.next', 'static')
     })
 
+    await uploadFolderToS3(s3Client, {
+      Bucket: nextRenderServerStackOutput.StaticBucketName,
+      Key: 'public',
+      folderRootPath: path.join(
+        outputPath,
+        '.next',
+        'standalone',
+        path.relative(projectSettings.root, projectSettings.projectPath),
+        'public'
+      )
+    })
+
     // upload code version to bucket.
     await uploadFileToS3(s3Client, {
       Bucket: nextRenderServerStackOutput.RenderServerVersionsBucketName,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,10 @@ export interface CacheConfig {
 
 export interface DeployConfig {
   cache: CacheConfig
+  publicAssets?: {
+    prefix: string
+    ttl?: number
+  }
 }
 
 export type NextRedirects = Awaited<ReturnType<Required<NextConfig>['redirects']>>


### PR DESCRIPTION
# Enable Public Assets Support and Optimize CloudFront Caching

## Overview
This PR adds support for public assets handling, optimizes CloudFront caching configurations, and fixes DynamoDB tags validation issues.

## Key Changes

### 1. Public Assets Support
- Added automatic copying of `public` folder to standalone output
- Implemented S3 upload functionality for public assets with configurable prefix
- Added new CloudFront behavior pattern for public assets

### 2. CloudFront Optimizations
- Enabled Brotli and Gzip compression for all cache policies
- Added compression support for CloudFront behaviors
- Introduced new dedicated cache policy for public assets
- Updated cache policy configurations with compression settings

## Configuration Updates
Added new configuration options in `DeployConfig`:

```typescript
interface DeployConfig {
 cache: CacheConfig;
 publicAssets?: {
  prefix: string; // URL prefix for public assets
  ttl?: number; // Cache TTL in seconds
 }
}
```