### PR TITLE
feat/platform-1972: next urls handling support

### DIFF
--- a/src/cdk/constructs/OriginRequestLambdaEdge.ts
+++ b/src/cdk/constructs/OriginRequestLambdaEdge.ts
@@ -6,7 +6,7 @@ import * as logs from 'aws-cdk-lib/aws-logs'
 import * as iam from 'aws-cdk-lib/aws-iam'
 import path from 'node:path'
 import { buildLambda } from '../../common/esbuild'
-import { CacheConfig, NextRewrites } from '../../types'
+import { CacheConfig } from '../../types'
 
 interface OriginRequestLambdaEdgeProps extends cdk.StackProps {
   bucketName: string
@@ -16,7 +16,6 @@ interface OriginRequestLambdaEdgeProps extends cdk.StackProps {
   cacheConfig: CacheConfig
   bucketRegion?: string
   cachedRoutesMatchers: string[]
-  rewritesConfig: NextRewrites
 }
 
 const NodeJSEnvironmentMapping: Record<string, lambda.Runtime> = {
@@ -28,16 +27,8 @@ export class OriginRequestLambdaEdge extends Construct {
   public readonly lambdaEdge: cloudfront.experimental.EdgeFunction
 
   constructor(scope: Construct, id: string, props: OriginRequestLambdaEdgeProps) {
-    const {
-      bucketName,
-      bucketRegion,
-      renderServerDomain,
-      nodejs,
-      buildOutputPath,
-      cacheConfig,
-      cachedRoutesMatchers,
-      rewritesConfig
-    } = props
+    const { bucketName, bucketRegion, renderServerDomain, nodejs, buildOutputPath, cacheConfig, cachedRoutesMatchers } =
+      props
     super(scope, id)
 
     const nodeJSEnvironment = NodeJSEnvironmentMapping[nodejs ?? ''] ?? NodeJSEnvironmentMapping['20']
@@ -49,8 +40,7 @@ export class OriginRequestLambdaEdge extends Construct {
         'process.env.S3_BUCKET_REGION': JSON.stringify(bucketRegion ?? ''),
         'process.env.EB_APP_URL': JSON.stringify(renderServerDomain),
         'process.env.CACHE_CONFIG': JSON.stringify(cacheConfig),
-        'process.env.NEXT_CACHED_ROUTES_MATCHERS': JSON.stringify(cachedRoutesMatchers ?? []),
-        'process.env.NEXT_REWRITES_CONFIG': JSON.stringify(rewritesConfig ?? [])
+        'process.env.NEXT_CACHED_ROUTES_MATCHERS': JSON.stringify(cachedRoutesMatchers ?? [])
       }
     })
 

--- a/src/cdk/constructs/RenderServerDistribution.ts
+++ b/src/cdk/constructs/RenderServerDistribution.ts
@@ -20,8 +20,8 @@ interface RenderServerDistributionProps {
 }
 
 const NodeJSEnvironmentMapping: Record<string, string> = {
-  '18': '64bit Amazon Linux 2023 v6.2.2 running Node.js 18',
-  '20': '64bit Amazon Linux 2023 v6.2.2 running Node.js 20'
+  '18': '64bit Amazon Linux 2023 v6.4.3 running Node.js 18',
+  '20': '64bit Amazon Linux 2023 v6.4.3 running Node.js 20'
 }
 
 export class RenderServerDistribution extends Construct {

--- a/src/cdk/constructs/RenderWorkerDistribution.ts
+++ b/src/cdk/constructs/RenderWorkerDistribution.ts
@@ -12,8 +12,8 @@ import { addOutput } from '../../common/cdk'
  * Maps version numbers to their corresponding Amazon Linux 2023 solution stack names
  */
 const NODE_VERSIONS: Record<string, string> = {
-  '18': '64bit Amazon Linux 2023 v6.2.2 running Node.js 18',
-  '20': '64bit Amazon Linux 2023 v6.2.2 running Node.js 20'
+  '18': '64bit Amazon Linux 2023 v6.4.3 running Node.js 18',
+  '20': '64bit Amazon Linux 2023 v6.4.3 running Node.js 20'
 } as const
 
 /**

--- a/src/cdk/constructs/ViewerRequestLambdaEdge.ts
+++ b/src/cdk/constructs/ViewerRequestLambdaEdge.ts
@@ -6,13 +6,15 @@ import * as logs from 'aws-cdk-lib/aws-logs'
 import * as iam from 'aws-cdk-lib/aws-iam'
 import path from 'node:path'
 import { buildLambda } from '../../common/esbuild'
-import { NextRedirects, NextI18nConfig } from '../../types'
+import { NextRedirects, NextI18nConfig, NextRewrites } from '../../types'
 
 interface ViewerRequestLambdaEdgeProps extends cdk.StackProps {
   buildOutputPath: string
   nodejs?: string
-  redirects?: NextRedirects
+  redirectsConfig?: NextRedirects
   nextI18nConfig?: NextI18nConfig
+  isTrailingSlashEnabled: boolean
+  rewritesConfig: NextRewrites
 }
 
 const NodeJSEnvironmentMapping: Record<string, lambda.Runtime> = {
@@ -24,7 +26,7 @@ export class ViewerRequestLambdaEdge extends Construct {
   public readonly lambdaEdge: cloudfront.experimental.EdgeFunction
 
   constructor(scope: Construct, id: string, props: ViewerRequestLambdaEdgeProps) {
-    const { nodejs, buildOutputPath, redirects, nextI18nConfig } = props
+    const { nodejs, buildOutputPath, redirectsConfig, nextI18nConfig, isTrailingSlashEnabled, rewritesConfig } = props
     super(scope, id)
 
     const nodeJSEnvironment = NodeJSEnvironmentMapping[nodejs ?? ''] ?? NodeJSEnvironmentMapping['20']
@@ -32,8 +34,10 @@ export class ViewerRequestLambdaEdge extends Construct {
 
     buildLambda(name, buildOutputPath, {
       define: {
-        'process.env.REDIRECTS': JSON.stringify(redirects ?? []),
-        'process.env.LOCALES_CONFIG': JSON.stringify(nextI18nConfig ?? null)
+        'process.env.REDIRECTS': JSON.stringify(redirectsConfig ?? []),
+        'process.env.LOCALES_CONFIG': JSON.stringify(nextI18nConfig ?? null),
+        'process.env.IS_TRAILING_SLASH_ENABLED': JSON.stringify(isTrailingSlashEnabled),
+        'process.env.NEXT_REWRITES_CONFIG': JSON.stringify(rewritesConfig ?? [])
       }
     })
 

--- a/src/cdk/stacks/NextCloudfrontStack.ts
+++ b/src/cdk/stacks/NextCloudfrontStack.ts
@@ -15,10 +15,11 @@ export interface NextCloudfrontStackProps extends StackProps {
   buildOutputPath: string
   deployConfig: DeployConfig
   imageTTL?: number
-  redirects?: NextRedirects
+  redirectsConfig?: NextRedirects
   nextI18nConfig?: NextI18nConfig
   cachedRoutesMatchers: string[]
   rewritesConfig: NextRewrites
+  isTrailingSlashEnabled: boolean
 }
 
 export class NextCloudfrontStack extends Stack {
@@ -37,10 +38,11 @@ export class NextCloudfrontStack extends Stack {
       region,
       deployConfig,
       imageTTL,
-      redirects,
+      redirectsConfig,
       cachedRoutesMatchers,
       nextI18nConfig,
-      rewritesConfig
+      rewritesConfig,
+      isTrailingSlashEnabled
     } = props
 
     this.originRequestLambdaEdge = new OriginRequestLambdaEdge(this, `${id}-OriginRequestLambdaEdge`, {
@@ -50,15 +52,16 @@ export class NextCloudfrontStack extends Stack {
       buildOutputPath,
       cacheConfig: deployConfig.cache,
       bucketRegion: region,
-      cachedRoutesMatchers,
-      rewritesConfig
+      cachedRoutesMatchers
     })
 
     this.viewerRequestLambdaEdge = new ViewerRequestLambdaEdge(this, `${id}-ViewerRequestLambdaEdge`, {
       buildOutputPath,
       nodejs,
-      redirects,
-      nextI18nConfig
+      redirectsConfig,
+      rewritesConfig,
+      nextI18nConfig,
+      isTrailingSlashEnabled
     })
 
     this.viewerResponseLambdaEdge = new ViewerResponseLambdaEdge(this, `${id}-ViewerResponseLambdaEdge`, {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -85,8 +85,8 @@ export const deploy = async (config: DeployConfig) => {
     const deployConfig = await loadConfig()
 
     const nextConfig = (await loadFile(projectSettings.nextConfigPath)) as NextConfig
-    const nextRedirects = nextConfig.redirects ? await nextConfig.redirects() : undefined
     const nextI18nConfig = nextConfig.i18n
+    const isTrailingSlashEnabled = nextConfig.trailingSlash ?? false
 
     const outputPath = createOutputFolder()
 
@@ -113,7 +113,7 @@ export const deploy = async (config: DeployConfig) => {
     const siteNameLowerCased = siteName.toLowerCase()
 
     // Build and zip app.
-    const { cachedRoutesMatchers, rewritesConfig } = await buildApp({
+    const { cachedRoutesMatchers, rewritesConfig, redirectsConfig } = await buildApp({
       projectSettings,
       outputPath
     })
@@ -156,9 +156,10 @@ export const deploy = async (config: DeployConfig) => {
         deployConfig,
         imageTTL: nextConfig.imageTTL,
         nextI18nConfig,
-        redirects: nextRedirects,
+        redirectsConfig,
         cachedRoutesMatchers,
         rewritesConfig,
+        isTrailingSlashEnabled,
         env: {
           region: AWS_EDGE_REGION // required since Edge can be deployed only here.
         }

--- a/src/lambdas/originRequest.ts
+++ b/src/lambdas/originRequest.ts
@@ -1,7 +1,7 @@
 import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3'
 import type { CloudFrontRequestEvent, CloudFrontRequestCallback, CloudFrontRequest, Context } from 'aws-lambda'
 import crypto from 'node:crypto'
-import { CacheConfig, NextRewrites, NextRewriteEntity } from '../types'
+import { CacheConfig } from '../types'
 import {
   transformQueryToObject,
   transformCookiesToObject,
@@ -93,57 +93,6 @@ const shouldRevalidateFile = (s3FileMeta: { LastModified: Date | string; CacheCo
   return isFileExpired
 }
 
-/**
- * Validates if a CloudFront request matches the conditions specified in the 'has' property of a rewrite rule
- * @param request - The CloudFront request object to validate
- * @param has - Array of conditions to check (header, query param, or cookie)
- * @returns True if all conditions match or if no conditions specified, false otherwise
- */
-const validateRouteHasMatch = (request: CloudFrontRequest, has: NextRewriteEntity['has']) => {
-  if (!has) return true
-
-  return has.every((h) => {
-    if (h.type === 'header') {
-      const header = request.headers[h.key]
-
-      return h.value ? header?.some((header) => header.value === h.value) : !!header
-    }
-
-    if (h.type === 'query' && request.querystring) {
-      const searchParams = new URLSearchParams(request.querystring)
-
-      return h.value ? searchParams.get(h.key) === h.value : searchParams.has(h.key)
-    }
-
-    if (h.type === 'cookie') {
-      const cookies = request.headers.cookie?.[0].value
-
-      return cookies?.includes(`${h.key}=${h.value ?? ''}`)
-    }
-
-    return false
-  })
-}
-
-/**
- * Checks if a CloudFront request matches any rewrite rules and updates the URI if matched
- * @param request - The CloudFront request object to validate and potentially modify
- * @param rewritesConfig - Array of rewrite rules to check against
- */
-const validateRewriteRoute = (request: CloudFrontRequest, rewritesConfig: NextRewrites) => {
-  const rewriteRoute = rewritesConfig.find((rewrite) => {
-    const { regex, has } = rewrite
-
-    const hasMatches = validateRouteHasMatch(request, has)
-
-    return hasMatches && new RegExp(regex).test(request.uri)
-  })
-
-  if (rewriteRoute) {
-    request.uri = rewriteRoute.destination
-  }
-}
-
 export const handler = async (
   event: CloudFrontRequestEvent,
   _context: Context,
@@ -153,11 +102,8 @@ export const handler = async (
   const s3Bucket = process.env.S3_BUCKET!
   const cacheConfig = process.env.CACHE_CONFIG as CacheConfig
   const nextCachedRoutesMatchers = process.env.NEXT_CACHED_ROUTES_MATCHERS as unknown as string[]
-  const nextRewritesConfig = process.env.NEXT_REWRITES_CONFIG as unknown as NextRewrites
   const { s3Key } = getS3ObjectPath(request, cacheConfig)
   const ebAppUrl = process.env.EB_APP_URL!
-
-  validateRewriteRoute(request, nextRewritesConfig)
 
   const isCachedRoute = nextCachedRoutesMatchers.some((matcher) => RegExp(matcher).test(request.uri))
 

--- a/src/lambdas/utils/nextRoute.ts
+++ b/src/lambdas/utils/nextRoute.ts
@@ -1,0 +1,88 @@
+/* eslint-disable no-useless-escape */
+import type { CloudFrontRequest } from 'aws-lambda'
+import type { NextRewriteEntity, NextRewrites, NextRedirects } from '../../types'
+
+/**
+ * Validates if a request matches the specified route conditions
+ * @param request - The CloudFront request object to validate
+ * @param has - Array of conditions to check (headers, query params, cookies)
+ * @returns boolean indicating if all conditions match
+ */
+export const validateRouteHasMatch = (request: CloudFrontRequest, has: NextRewriteEntity['has']) => {
+  if (!has) return true
+
+  return has.every((h) => {
+    if (h.type === 'header') {
+      const header = request.headers[h.key]
+
+      return h.value ? header?.some((header) => header.value === h.value) : !!header
+    }
+
+    if (h.type === 'query' && request.querystring) {
+      const searchParams = new URLSearchParams(request.querystring)
+
+      return h.value ? searchParams.get(h.key) === h.value : searchParams.has(h.key)
+    }
+
+    if (h.type === 'cookie') {
+      const cookies = request.headers.cookie?.[0].value
+
+      return cookies?.includes(`${h.key}=${h.value ?? ''}`)
+    }
+
+    return false
+  })
+}
+
+/**
+ * Processes a request against rewrite/redirect rules to determine the updated route
+ * @param request - The CloudFront request object to process
+ * @param rules - Array of rewrite or redirect rules to apply
+ * @param isTrailingSlashEnabled - Whether trailing slashes should be enforced
+ * @returns Object containing the new URL and matched rule, or undefined if no match
+ */
+export const getUpdatedRoute = (
+  request: CloudFrontRequest,
+  rules: NextRewrites | NextRedirects,
+  isTrailingSlashEnabled: boolean
+) => {
+  for (const rule of rules) {
+    const { regex, has, source, destination } = rule
+    const hasMatches = validateRouteHasMatch(request, has)
+
+    if (hasMatches) {
+      const regexFn = new RegExp(regex)
+      const match = regexFn.exec(request.uri)
+
+      if (match) {
+        const paramNames = source.match(/\:(\w+)(\*)?/g)?.map((param) => param.replace(/[:*]/g, '')) || []
+
+        // Create params object by mapping names to capture groups
+        // First group [0] is full match, so we start from [1]
+        const params = paramNames.reduce(
+          (acc, name, index) => {
+            acc[name] = match[index + 1] || ''
+            return acc
+          },
+          {} as Record<string, string>
+        )
+
+        // Replace parameters in destination
+        let updatedUrlDestintaion = destination.replace(/\:(\w+)(\*)?/g, (_, name) => {
+          return params[name] || ''
+        })
+        const containsTrailingSlash = updatedUrlDestintaion.endsWith('/')
+
+        if (isTrailingSlashEnabled && !containsTrailingSlash) {
+          updatedUrlDestintaion = `${updatedUrlDestintaion}/`
+        }
+
+        if (!isTrailingSlashEnabled && containsTrailingSlash) {
+          updatedUrlDestintaion = updatedUrlDestintaion.slice(0, -1)
+        }
+
+        return { newUrl: updatedUrlDestintaion, rule }
+      }
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,8 +16,6 @@ export interface DeployConfig {
   }
 }
 
-export type NextRedirects = Awaited<ReturnType<Required<NextConfig>['redirects']>>
-
 export type NextI18nConfig = NextConfig['i18n']
 
 export type NextRewriteEntity = {
@@ -27,4 +25,14 @@ export type NextRewriteEntity = {
   has?: RouteHas[]
 }
 
+export type NextRedirectEntity = {
+  source: string
+  destination: string
+  has?: RouteHas[]
+  regex: string
+  statusCode: number
+}
+
 export type NextRewrites = NextRewriteEntity[]
+
+export type NextRedirects = NextRedirectEntity[]


### PR DESCRIPTION
# Add Support for Next.js Redirects and Trailing Slashes

## Overview
This PR adds support for Next.js redirects and trailing slashes configuration, improves route handling, and updates the Elastic Beanstalk platform versions.

## Key Changes

### 1. Next.js Redirects Support
- Added support for Next.js redirects configuration
- Implemented redirect handling in viewer request Lambda@Edge
- Added proper status code handling for redirects (307/308)
- Added support for locale-based redirects

### 2. Next.js Rewrites Support
- Added support for Next.js rewrites configuration
- Implemented rewrites handling in viewer request Lambda@Edge

### 3. Route Handling Improvements
- Moved rewrite logic from origin request to viewer request Lambda
- Added unified route handling utility (`nextRoute.ts`)
- Added support for dynamic route parameters
- Improved handling of query parameters and headers

### 4. Trailing Slashes Support
- Added support for Next.js `trailingSlash` configuration
- Implemented consistent trailing slash handling across redirects and rewrites
- Added configuration option `isTrailingSlashEnabled`

### 5. Platform Updates
- Updated Elastic Beanstalk platform versions to:
  - Node.js 18: `64bit Amazon Linux 2023 v6.4.3`
  - Node.js 20: `64bit Amazon Linux 2023 v6.4.3`

