### PR TITLE
feat: added healtcheck and added locales to regexs

### DIFF
--- a/src/build/next.ts
+++ b/src/build/next.ts
@@ -98,10 +98,16 @@ export const getNextCachedRoutesConfig = async (
   const prerenderManifest = JSON.parse(prerenderManifestJSON) as PrerenderManifest
   const routesManifest = JSON.parse(routesManifestJSON) as RoutesManifest
 
+  const locales = routesManifest.i18n?.locales ?? []
+
   const cachedRoutesMatchers = [...routesManifest.dynamicRoutes, ...routesManifest.staticRoutes].reduce(
     (prev, route) => {
       if (prerenderManifest.routes?.[route.page] || prerenderManifest.dynamicRoutes?.[route.page]) {
-        prev.push(route.regex)
+        if (locales.length) {
+          prev.push(...locales.map((locale) => route.regex.replace('^', `^/${locale}`)))
+        } else {
+          prev.push(route.regex)
+        }
       }
 
       return prev

--- a/src/cdk/constructs/CloudFrontDistribution.ts
+++ b/src/cdk/constructs/CloudFrontDistribution.ts
@@ -24,7 +24,7 @@ const OneMonthCache = Duration.days(30)
 const NoCache = Duration.seconds(0)
 
 const defaultNextQueries = ['_rsc']
-const defaultNextHeaders = ['Cache-Control', 'Next-Router-State-Tree', 'Next-Url', 'Rsc', 'Next-Router-Prefetch']
+const defaultNextHeaders = ['Next-Router-State-Tree', 'Next-Url', 'Rsc', 'Next-Router-Prefetch']
 const imageQueries = ['w', 'h', 'url', 'q']
 export class CloudFrontDistribution extends Construct {
   public readonly cf: cloudfront.Distribution

--- a/src/cdk/stacks/NextRenderServerStack.ts
+++ b/src/cdk/stacks/NextRenderServerStack.ts
@@ -16,6 +16,7 @@ export interface NextRenderServerStackProps extends cdk.StackProps {
   renderServerInstanceType?: string
   renderServerMinInstances?: number
   renderServerMaxInstances?: number
+  healthCheckPath?: string
 }
 
 export class NextRenderServerStack extends cdk.Stack {
@@ -35,7 +36,8 @@ export class NextRenderServerStack extends cdk.Stack {
       region,
       renderServerInstanceType,
       renderServerMinInstances,
-      renderServerMaxInstances
+      renderServerMaxInstances,
+      healthCheckPath
     } = props
 
     this.staticBucketName = `${id}-static`
@@ -68,7 +70,8 @@ export class NextRenderServerStack extends cdk.Stack {
       instanceType: renderServerInstanceType,
       minInstances: renderServerMinInstances,
       maxInstances: renderServerMaxInstances,
-      dynamoDBCacheTable: this.dynamoDB.table.tableName
+      dynamoDBCacheTable: this.dynamoDB.table.tableName,
+      healthCheckPath
     })
 
     this.renderWorker = new RenderWorkerDistribution(this, `${id}-renderWorker`, {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -133,6 +133,7 @@ export const deploy = async (config: DeployConfig) => {
         renderServerInstanceType,
         renderServerMaxInstances,
         renderServerMinInstances,
+        healthCheckPath: deployConfig.healthCheckPath,
         env: {
           region
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface CacheConfig {
 
 export interface DeployConfig {
   cache: CacheConfig
+  healthCheckPath?: string
   publicAssets?: {
     prefix: string
     ttl?: number


### PR DESCRIPTION
# Internationalization & Health Check Improvements

## Overview
This PR implements i18n routes support, optimizes CloudFront caching configurations, adds advanced ElasticBeanstalk health check capabilities, and improves autoscaling performance.

## Changes

### Internationalization Support
- Added handling for localized routes in Next.js rendering and caching
- Now properly processes i18n routes with locale prefixes (e.g., `/en-US/about`) in cached routes configuration
- Ensures proper caching and routing for multi-language applications

### CloudFront Distribution Optimizations
- Removed 'Cache-Control' from default forwarded headers list to improve cache hit ratio
- Prevents unnecessary cache invalidation from varying Cache-Control headers

### ElasticBeanstalk Improvements
- Added custom health check path configuration:
  - Can now specify custom endpoint for health checks through `healthCheckPath` parameter
  - Default path is root (`/`) if not specified
- Improved logging capabilities:
  - Enabled CloudWatch log streaming for better visibility into application performance
  - Added IAM permissions for proper log streaming management
- Optimized auto-scaling settings:
  - Adjusted resource threshold triggers to improve cost efficiency
  - Modified upper threshold from 75% to 60% and lower threshold from 40% to 30% for earlier scaling actions

### Infrastructure Quality of Life
- Added consistent deployment configuration options
- Parameter forwarding from deploy command to infrastructure stacks

## Technical Details
- Modified i18n route regex generation to properly account for locale prefixes
- Added appropriate IAM permissions for CloudWatch logs integration
- Propagated health check path configuration through deployment chain

## How to Use
The health check path can now be specified in deployment configuration:

```js
// next-serverless.config.js
module.exports = {
  cache: {
    // cache settings
  },
  healthCheckPath: '/api/health' // Custom health check endpoint
}
```

## Testing
- Tested with both i18n and non-i18n Next.js applications
- Verified proper functioning of health checks with custom paths
- Confirmed CloudWatch log streaming works correctly 